### PR TITLE
Adding in fix for querying a list of activities

### DIFF
--- a/src/main/java/com/hackathon/springboard/beneficiarycollaborationservice/services/ActivityService.java
+++ b/src/main/java/com/hackathon/springboard/beneficiarycollaborationservice/services/ActivityService.java
@@ -96,6 +96,10 @@ public class ActivityService {
 
     String expressionStatement = "";
 
+    if (listOfExpressions.isEmpty()) {
+      expressionStatement = expression.expression();
+    }
+
     for (Expression ex : listOfExpressions) {
       expressionStatement = Expression
           .join(


### PR DESCRIPTION
The reason for this is that the expression statement was empty when not providing a filter criteria